### PR TITLE
[ Fix ] KeyError: 'ideal_import_kwh_tou' when monthly usage exceeds 600 kWh

### DIFF
--- a/custom_components/tnb_calculator/sensor.py
+++ b/custom_components/tnb_calculator/sensor.py
@@ -2972,6 +2972,8 @@ class TNBDataCoordinator(DataUpdateCoordinator):
         return {
             # Main sensor values
             "ideal_import_kwh": self._round_energy(current_import),
+            "ideal_import_kwh_tou": self._round_energy(current_import),
+            "ideal_import_kwh_non_tou": self._round_energy(current_import),
             "savings_if_ideal_kwh": 0.0,
             "afa_optimization_savings": 0.0,
             "afa_weird_zone": False,


### PR DESCRIPTION

**The Bug:**
When a user's monthly import energy reaches or exceeds the 600 kWh AFA threshold, the integration throws a KeyError: 'ideal_import_kwh_tou' and fails to update/setup the sensors.

**The Cause:**
In sensor.py, the _async_update_data function expects the optimization data dictionary to contain ideal_import_kwh_tou and ideal_import_kwh_non_tou. However, when usage is >= 600 kWh, the _build_above_threshold_result function handles the response and was missing these two specific keys in its returned dictionary.

**The Fix:**
Added the missing ideal_import_kwh_tou and ideal_import_kwh_non_tou keys to the return dictionary in _build_above_threshold_result. They are set to self._round_energy(current_import) to safely mirror the behavior of the base ideal_import_kwh key (since the user is already over the threshold, their "ideal" target defaults to their current usage). This satisfies the main update loop and prevents the crash.